### PR TITLE
Updated Experiments API to mlflow 2.x spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const {Experiments, Runs, Metrics, Artifacts} = client
 ;(async () => {
 	
 	// Get list of all experiments
-	const {experiments} = await Experiments.list()
+	const {experiments} = await Experiments.search(max_results: 1000)
 	const experiment = experiments[0]
 	
 	// Get list of all active runs in specific experiment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,39 +1,91 @@
 {
   "name": "mlflow",
-  "version": "2.0.0",
-  "lockfileVersion": 1,
+  "version": "2.0.7",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/node": {
+  "packages": {
+    "": {
+      "name": "mlflow",
+      "version": "2.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic-unfetch": "^3.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^12.7.2",
+        "typescript": "^3.5.3"
+      }
+    },
+    "node_modules/@types/node": {
       "version": "12.7.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
       "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
       "dev": true
     },
-    "isomorphic-unfetch": {
+    "node_modules/isomorphic-unfetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.0.0.tgz",
       "integrity": "sha512-V0tmJSYfkKokZ5mgl0cmfQMTb7MLHsBMngTkbLY0eXvKqiVRRoZP04Ly+KhKrJfKtzC9E6Pp15Jo+bwh7Vi2XQ==",
-      "requires": {
+      "dependencies": {
         "node-fetch": "^2.2.0",
         "unfetch": "^4.0.0"
       }
     },
-    "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
-    "typescript": {
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/typescript": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
       "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
-    "unfetch": {
+    "node_modules/unfetch": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
       "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mlflow",
-  "version": "2.0.7",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mlflow",
-      "version": "2.0.7",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow",
-  "version": "2.0.7",
+  "version": "3.0.0",
   "description": "MLflow api client for Node.js",
   "main": "index.js",
   "types": "lib/mlflow.d.ts",

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -18,12 +18,17 @@ export default class Experiments extends MLflowBase {
 		return this.req('post', '/create', {name, artifact_location})
 	}
 	
-	list({view_type}:{
-		view_type?: ViewType
-	}={}):Promise<{
-		experiments: Experiment[]
+	search({filter, run_view_type, max_results, order_by, page_token}:{
+		filter?: string,
+		run_view_type?: ViewType,
+		max_results?: number,
+		order_by?: string[],
+		page_token?: string
+	}):Promise<{
+		experiments: Experiment[],
+		next_page_token: string
 	}> {
-		return this.req('get', '/list', {view_type})
+		return this.req('post', '/search', {filter, run_view_type, max_results, order_by, page_token})
 	}
 	
 	get({experiment_id}:{


### PR DESCRIPTION
It looks like the REST API endpoint for experiments search changed
from /api/2.0/mlflow/experiments/list
to /api/2.0/mlflow/experiments/search
at some point since that library was written:
[mlflow REST API docs](https://mlflow.org/docs/latest/rest-api.html#search-experiments)

This is a breaking change in that we have removed the `list` functionality
since it was already broken/missing from recent MLflow versions